### PR TITLE
Workaround for NoMethodError by specifying selenium-webdriver version

### DIFF
--- a/kimurai.gemspec
+++ b/kimurai.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "capybara", ">= 2.15", "< 4.0"
   spec.add_dependency "capybara-mechanize"
   spec.add_dependency "poltergeist"
+  # lock selenium-webdriver version as workaround for assume_untrusted_certificate_issuer NoMethodError for now
+  # TO-DO: come back around and either fix kimurai to not rely on that method or bump selenium-webdriver when they fix it
   spec.add_dependency "selenium-webdriver", "3.142.7"
   spec.add_dependency "cuprite"
 

--- a/kimurai.gemspec
+++ b/kimurai.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "capybara", ">= 2.15", "< 4.0"
   spec.add_dependency "capybara-mechanize"
   spec.add_dependency "poltergeist"
-  spec.add_dependency "selenium-webdriver"
+  spec.add_dependency "selenium-webdriver", "3.142.7"
   spec.add_dependency "cuprite"
 
   spec.add_dependency "headless"


### PR DESCRIPTION
It looks like updated versions of selenium-webdriver don't have the `assume_untrusted_certificate_issuer` method, leading to errors like the following when trying to run spiders from the openregs repo, which currently uses the feature/add-cuprite-driver branch.
From the openregs Gemfile:
`gem "kimurai", git: "https://github.com/kindsys/kimuraframework", branch: "feature/add-cuprite-driver"`

Error when trying to run a spider, e.g. `be thor spider:crawl NM-STAT`
```
1: from /Users/gracexu/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/capybara-3.35.3/lib/capybara/session.rb:104:in `driver'
/Users/gracexu/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/bundler/gems/kimuraframework-e1994babff19/lib/kimurai/browser_builder/selenium_firefox_builder.rb:71:in `block in build': undefined method `assume_untrusted_certificate_issuer=' for #<Selenium::WebDriver::Firefox::Profile:0x0000000103b32f50> (NoMethodError) 
```

Specifying the 3.142.7 version of selenium-webdriver as in this commit resolves the issue (you will need to delete your Gemfile.lock in the openregs repo and re-run `bundle install` and/or `gem pristine --all`).